### PR TITLE
LLM reason information added in verbose mode for novarun

### DIFF
--- a/nova/core/matcher.py
+++ b/nova/core/matcher.py
@@ -263,6 +263,7 @@ class NovaMatcher:
         all_semantic_scores = {}
         all_llm_matches = {}
         all_llm_scores = {}
+        all_llm_details = {}
 
         # Initialize filtered dictionaries to hold results needed for condition evaluation
         keyword_matches = {}
@@ -285,7 +286,8 @@ class NovaMatcher:
                     'condition_result': condition_result,
                     'all_keyword_matches': all_keyword_matches,
                     'all_semantic_matches': all_semantic_matches,
-                    'all_llm_matches': all_llm_matches
+                    'all_llm_matches': all_llm_matches,
+                    'all_llm_details': all_llm_details
                 }
             }
 
@@ -379,12 +381,17 @@ class NovaMatcher:
                         all_llm_matches[key] = matched
                         all_llm_scores[key] = confidence
                         llm_matches[key] = matched
+                        all_llm_details[key] = details
                     except Exception as e:
                         logger.error(f"Error evaluating llm.{key}: {str(e)}")
                         all_llm_matches[key] = False
                         all_llm_scores[key] = 0.0
                         llm_matches[key] = False
 
+                        all_llm_details[key] = {
+                            "error": str(e),
+                            "evaluator_type": "unknown",
+                        }
             # Update llm_matches for wildcards
             if 'llm' in needed_patterns['section_wildcards']:
                 llm_matches.update(all_llm_matches)

--- a/nova/evaluators/condition.py
+++ b/nova/evaluators/condition.py
@@ -302,6 +302,27 @@ def validate_regex(pattern):
 
 
 # Fix for None prompt handling in the matcher
+def can_llm_change_outcome(condition: str, keyword_matches: Dict[str, bool], semantic_matches: Dict[str, bool]) -> bool:
+    """Check if LLM patterns could change the outcome based on keyword and semantic matches.
+    
+    NOTE: This is a placeholder stub - actual logic not implemented yet.
+    Returns True to ensure LLM evaluations are always performed.
+    """
+    return True
+
+
+
+# Placeholder stub - actual logic not implemented yet
+def can_semantics_change_outcome(condition: str, keyword_matches: Dict[str, bool]) -> bool:
+    """Check if semantic patterns could change the outcome based on keyword matches.
+    
+    NOTE: This is a placeholder stub - actual logic not implemented yet.
+    Returns True to ensure semantic evaluations are always performed.
+    """
+    return True
+
+
+# Fix for None prompt handling in the matcher
 def check_prompt_safe(prompt, matcher_obj):
     """
     Safely check a prompt against a rule, handling None and other edge cases.

--- a/nova/novarun.py
+++ b/nova/novarun.py
@@ -319,6 +319,27 @@ def print_section_header(title, char="-"):
     print(f"{Fore.YELLOW}{title}")
     print(f"{Fore.YELLOW}{char*70}")
 
+def print_llm_reasons(result: Dict[str, Any]) -> None:
+    debug = result.get("debug", {})
+    llm_details = debug.get("all_llm_details", {})
+    debug = result.get("debug", {})
+    llm_details = debug.get("all_llm_details", {})
+    """Print LLM reason fields captured by NovaMatcher."""
+    debug = result.get("debug", {})
+    llm_details = debug.get("all_llm_details", {})
+    reasons = {
+        key: details.get("reason")
+        for key, details in llm_details.items()
+        if isinstance(details, dict) and details.get("reason")
+    }
+    if not reasons:
+        return
+
+    print(f"\n{Fore.MAGENTA}LLM Reason:")
+    for key, reason in reasons.items():
+        print(f"  {Fore.CYAN}{key}: {Fore.WHITE}{reason}")
+
+
 
 def print_result(result: Dict[str, Any], rule_path: str, prompt: str, verbose: bool = False, 
                  rule_number=None, total_rules=None, prompt_number=None, total_prompts=None) -> None:
@@ -425,6 +446,8 @@ def print_result(result: Dict[str, Any], rule_path: str, prompt: str, verbose: b
                         score_color = Fore.GREEN if value >= 0.7 else Fore.YELLOW if value >= 0.5 else Fore.RED
                         print(f"  {Fore.CYAN}{key}: {score_color}{value:.4f}")
 
+                # Print LLM reasons in verbose mode
+                print_llm_reasons(result)
 
 def print_summary(matched_count: int, total_rules: int):
     """


### PR DESCRIPTION
Hello, I've added a few lines of code to print in verbose mode the "LLM reason" detail. I found it useful to debug and write better Nova rules that involve LLMs. I've added the two missing functions as placeholders (they always return True) in condition.py in order to avoid changing the logic and imports in matcher.py as explained in https://github.com/Nova-Hunting/nova-framework/issues/22 . 

<img width="3185" height="1673" alt="image" src="https://github.com/user-attachments/assets/45164203-5cc7-4a2b-8eb6-3c5f1cf1acab" />
